### PR TITLE
feat: add deployment version label and simplify image tag handling

### DIFF
--- a/charts/l7-services/Chart.yaml
+++ b/charts/l7-services/Chart.yaml
@@ -17,4 +17,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.1.0

--- a/charts/l7-services/templates/deployment.yaml
+++ b/charts/l7-services/templates/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "var.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
+    deployment-version: {{ .Values.image.tag }}
     {{- include "var.labels" . | nindent 4 }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
@@ -36,7 +37,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http


### PR DESCRIPTION
Added a new deployment-version label to the metadata for better tracking of deployment versions. Simplified the image tag handling in the deployment spec by removing the default value fallback to ensure consistency.