### PR TITLE
fix: move version label in deployment template

### DIFF
--- a/charts/l7-services/Chart.yaml
+++ b/charts/l7-services/Chart.yaml
@@ -17,4 +17,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.1.1

--- a/charts/l7-services/templates/deployment.yaml
+++ b/charts/l7-services/templates/deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   name: {{ include "var.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    deployment-version: {{ .Values.image.tag }}
     {{- include "var.labels" . | nindent 4 }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
@@ -20,6 +19,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
+        service-version: {{ $.Values.image.tag }}
         {{- include "var.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}


### PR DESCRIPTION
Removed deployment-version label from metadata and added service-version label to pod template labels for better clarity and consistency. This ensures the correct versioning context for the service.