### PR TITLE
fix: Pub/Sub subscription reference in YAML template

### DIFF
--- a/charts/l7-services/Chart.yaml
+++ b/charts/l7-services/Chart.yaml
@@ -17,4 +17,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.2
+version: 1.1.3

--- a/charts/l7-services/templates/pubsub-subscription.yaml
+++ b/charts/l7-services/templates/pubsub-subscription.yaml
@@ -84,6 +84,6 @@ spec:
     member: "serviceAccount:service-{{ $.Values.gcpProjectNumber }}@gcp-sa-pubsub.iam.gserviceaccount.com"
     role: roles/pubsub.subscriber
     subscriptionRef:
-      name: {{ .name }}-dead-letter-sub
+      name: {{ .name }}
 {{- end}}
 {{- end}}


### PR DESCRIPTION
The dead-letter subscription name was mistakenly appended, resulting in deployment issues. This change corrects the subscription reference to use the intended name without the dead-letter suffix.