### PR TITLE
chore: clarify manual version bump requirement for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # public-helm-chart
+
+# Release
+
+⚠️ At the moment you have to increase the version in the file [Chart.yaml](./charts/l7-services/Chart.yaml) manually.
+Otherwise, the release pipeline will fail.


### PR DESCRIPTION
Add a note in the README explaining the need to manually increment the version in `Chart.yaml` to avoid pipeline failures. This ensures proper guidance for maintaining the release process.